### PR TITLE
Fixing mobile layout on /data

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -1,55 +1,73 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Marked Register Data Entry Service</title>
-<link rel="icon" type="image/x-icon" href="./../logo.jpg">
-<script src="./../script.js"></script>
-<link rel="stylesheet" href="./../styles.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Marked Register Data Entry Service</title>
+    <link rel="icon" type="image/x-icon" href="./../logo.jpg">
+    <script src="./../script.js"></script>
+    <link rel="stylesheet" href="./../styles.css">
 </head>
+
 <body>
-<header>
-<img src="./../logo.jpg" alt="Eryri Press Logo">
-<h1>Marked Register Data Entry Service</h1>
-</header>
-<p></p>
-<div>
-<a href="https://eryripress.co.uk" class="btn-top">CLICK HERE FOR OUR BULK POSTAGE SERVICE</a>
-</div>
-<p>Knowing whether a person normally votes at elections is a powerful piece of information for your campaign.</p>
-<p>To do this, you need to transfer your marked registers to the electoral database. We can help!</p>
-<p>The marked register is a copy of the electoral register that was used on Polling Day, showing who turned out to vote. Copies of the marked register are available for one year after the election.</p>
-<p>Eryri is working with local parties to make sure you don’t miss out on this valuable data.</p>
-<p>Has your local party purchased your marked registers already but no one knows how to upload the data? Or would you like us to purchase the files for you?</p>
-<div class="pricing">
-<p><strong>The cost of this service for a single parliamentary constituency or local authority area is:</strong></p>
-<ul>
-<li>£385 standard charge,</li>
-<li>Less £100 if you have already purchased the marked registers (in data/PDF form),</li>
-<li>As ever, all prices shown include VAT. To enquire, simply complete the below form.</li>
-</ul>
-<p>These price points can be adjusted <i>pro rata</i> for local authorities that are significantly larger than the average Westminster constituency.</p>
-</div>
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeZJtV0hbUWJArmVICuaYPeAUgLJMvIMaSFes7AKFxDsmft7A/viewform?embedded=true" width="640" height="1042" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-<div class="cta">
-<p><strong>Alternatively, to sign up for the service, please email Chris on <a href="mailto:enquiries@eryripress.co.uk">enquiries@eryripress.co.uk</a>.</strong></p>
-<p>We use the latest optical character recognition software to do this smoothly - but don't worry, all the data is verified by a human being!</p>
-</div>
-<div class="faq">
-<h2>FAQs</h2>
-<dl>
-<dt><b>Q. How accurate is the software?</b></dt>
-<dd>A. Provided the files are of a high enough quality, the software we use is about 99% accurate. This is as accurate as any volunteer – and so much quicker!</dd>
-<dt><b>Q. What causes failure?</b></dt>
-            <dd>A. The biggest problem we face when it comes to using the software is poor quality PDF files
-                from the local authority. If you are requesting the files, please specify that the scanned
-                pages must be of the highest possible quality to ensure that the OCR software can read them.</dd>
-<dt><b>Q. What about postal and proxy voters?</b></dt>
-            <dd>A. These are included free of charge, but it is most helpful if your council provides the
-                absent voter marked register in Excel/CSV format rather than a PDF.</dd>
-        </dl>
-    </div>
+    <header>
+        <img src="./../logo.jpg" alt="Eryri Press Logo">
+        <h1>Marked Register Data Entry Service</h1>
+    </header>
+    <main>
+        <div>
+            <a href="./../" class="btn-top">CLICK HERE FOR OUR BULK POSTAGE SERVICE</a>
+        </div>
+        <p>Knowing whether a person normally votes at elections is a powerful piece of information for your campaign.
+        </p>
+        <p>To do this, you need to transfer your marked registers to the electoral database. We can help!</p>
+        <p>The marked register is a copy of the electoral register that was used on Polling Day, showing who turned out
+            to
+            vote. Copies of the marked register are available for one year after the election.</p>
+        <p>Eryri is working with local parties to make sure you don’t miss out on this valuable data.</p>
+        <p>Has your local party purchased your marked registers already but no one knows how to upload the data? Or
+            would
+            you like us to purchase the files for you?</p>
+        <div class="pricing">
+            <p><strong>The cost of this service for a single parliamentary constituency or local authority area
+                    is:</strong>
+            </p>
+            <ul>
+                <li>£385 standard charge,</li>
+                <li>Less £100 if you have already purchased the marked registers (in data/PDF form),</li>
+                <li>As ever, all prices shown include VAT. To enquire, simply complete the below form.</li>
+            </ul>
+            <p>These price points can be adjusted <i>pro rata</i> for local authorities that are significantly larger
+                than
+                the average Westminster constituency.</p>
+        </div>
+        <iframe
+            src="https://docs.google.com/forms/d/e/1FAIpQLSeZJtV0hbUWJArmVICuaYPeAUgLJMvIMaSFes7AKFxDsmft7A/viewform?embedded=true"
+            width="640" height="1042" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+        <div class="cta">
+            <p><strong>Alternatively, to sign up for the service, please email Chris on <a
+                        href="mailto:enquiries@eryripress.co.uk">enquiries@eryripress.co.uk</a>.</strong></p>
+            <p>We use the latest optical character recognition software to do this smoothly - but don't worry, all the
+                data
+                is verified by a human being!</p>
+        </div>
+        <div class="faq">
+            <h2>FAQs</h2>
+            <dl>
+                <dt><b>Q. How accurate is the software?</b></dt>
+                <dd>A. Provided the files are of a high enough quality, the software we use is about 99% accurate. This
+                    is
+                    as accurate as any volunteer – and so much quicker!</dd>
+                <dt><b>Q. What causes failure?</b></dt>
+                <dd>A. The biggest problem we face when it comes to using the software is poor quality PDF files
+                    from the local authority. If you are requesting the files, please specify that the scanned
+                    pages must be of the highest possible quality to ensure that the OCR software can read them.</dd>
+                <dt><b>Q. What about postal and proxy voters?</b></dt>
+                <dd>A. These are included free of charge, but it is most helpful if your council provides the
+                    absent voter marked register in Excel/CSV format rather than a PDF.</dd>
+            </dl>
+        </div>
     </main>
     <footer>
         <img style="height: 100px; width: 100px;" src="./../logo.jpg">

--- a/styles.css
+++ b/styles.css
@@ -171,5 +171,5 @@ footer p {
 
 iframe[src="https://docs.google.com/forms/d/e/1FAIpQLSeZJtV0hbUWJArmVICuaYPeAUgLJMvIMaSFes7AKFxDsmft7A/viewform?embedded=true"] {
     width: 100%;
-    height: 1123px;
+    height: 1155px;
 }


### PR DESCRIPTION
Fixing the lack of margin on mobiles. Before:

![Screenshot_20240815-192627.png](https://github.com/user-attachments/assets/2033c9d4-4e59-40cf-9611-51be2f897bb6)

After:

![Screenshot_20240815-192727.png](https://github.com/user-attachments/assets/d4be79ad-5d32-491a-aff3-b7258aaec6e8)

---

Also changing one more thing. The button that takes you back to the homepage:

![image](https://github.com/user-attachments/assets/71994f26-4974-4c84-a029-82d3e4084874)

That doesn't work on the preview if you hardcode it to always go to `https://eryripress.co.uk` which is why I'm using the `./../` link. I see you've been changing it around - if you are having issues with it we can leave it hardcoded but this should be fine as far as I know.
